### PR TITLE
Removed link to https://github.com/swm11/tesla_api since active development is now under https://github.com/mlowijs/tesla_api

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ ___*** Please be patient as I have an unrelated day job! ***___
 
 **Please help me update this: Pull requests are welcome!**
 
-This is a list of api URLs and some random thoughts I've been able to pull together from the interwebs and other functions we've been able to reverse engineer from the local gateway.  This is not the [ Tesla Owner API] which you can find here: (https://tesla-api.timdorr.com) with a Python library that works nicely to control a Powerwall 2 here: (https://github.com/mlowijs/tesla_api), which is actively being developed here: (https://github.com/swm11/tesla_api).
+This is a list of api URLs and some random thoughts I've been able to pull together from the interwebs and other functions we've been able to reverse engineer from the local gateway.  This is not the [ Tesla Owner API] which you can find here: (https://tesla-api.timdorr.com) with a Python library that works nicely to control a Powerwall 2 here: (https://github.com/mlowijs/tesla_api).
 
-A python implementation of the local API can be found [here](https://github.com/jrester/tesla_powerwall).
+A python implementation of the local API can be found here (https://github.com/jrester/tesla_powerwall).
 -Thanks for submitting this: 
 
 


### PR DESCRIPTION
Removed link to https://github.com/swm11/tesla_api since active development is now under https://github.com/mlowijs/tesla_api