### PR TITLE
Updates after generating http client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 **/tmp-externalValues
+**/client/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+    "recommendations": [
+        "42crunch.vscode-openapi",
+        "github.copilot-nightly",
+        "streetsidesoftware.code-spell-checker"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+    "cSpell.words": [
+        "busway",
+        "openapi",
+        "Powerwall",
+        "powerwalls",
+        "protobuf",
+        "protoc",
+        "sitemaster",
+        "solars",
+        "vloschiavo"
+    ]
+}

--- a/openapi/CONTRIBUTING.md
+++ b/openapi/CONTRIBUTING.md
@@ -39,18 +39,30 @@ At the time of writing this CONTRIBUTING.md file, there are no deprecated endpoi
 
 ### Testing the Swagger UI on your forked copy
 
-Before submitting a pull request, please try out the Swagger UI on your forked copy.  You will need to enable GitHub Pages on your forked copy, and then you can access the Swagger UI at `https://<your-github-username>.github.io/powerwall2/openapi/`.  E.g. https://vloschiavo.github.io/powerwall2/openapi/.
+Before submitting a pull request, please try out the Swagger UI on your forked copy.  You will either need to enable GitHub Pages on your forked copy, and then you can access the Swagger UI at `https://<your-github-username>.github.io/powerwall2/openapi/`.  E.g. https://vloschiavo.github.io/powerwall2/openapi/, or you can use nginx to run up the Swagger UI locally.
+
+#### Using GitHub pages
 
 To enable GitHub Pages go to your forked copy of the repository, Settings --> Pages --> Source: Deploy from a branch --> Branch: <your branch name> --> Save.
 
 ![Enabling GitHub Pages on branch](enable-github-pages-on-branch.png)
+
+#### Using nginx
+
+To run up the Swagger UI viewer using nginx, you can use the docker compose file by running the following from the terminal: 
+
+```
+cd openapi
+
+docker compose up
+```
 
 ### Pre-Commit Checks
 
 Before submitting pull request changes to the OpenAPI specification, please try to run the pre-commit checks.  You can do this by installing [pre-commit](https://pre-commit.com/index.html#install) or by running a docker container with pre-commit already installed.  E.g.
 
 ```bash
- docker run --rm -v $(pwd):/data fxinnovation/pre-commit
+docker run --rm -v $(pwd):/data fxinnovation/pre-commit
 ```
 
 ### Repointing exampleValue references to vloschiavo's repository

--- a/openapi/GENERATING-CLIENTS-USING-OPENAPI-GENERATOR.md
+++ b/openapi/GENERATING-CLIENTS-USING-OPENAPI-GENERATOR.md
@@ -1,0 +1,20 @@
+## Generating a client using openapi-generator-cli
+
+From [their GitHub documentation](https://github.com/OpenAPITools/openapi-generator/) "OpenAPI Generator allows generation of API client libraries (SDK generation), server stubs, documentation and configuration automatically given an OpenAPI Spec".
+
+Below is an example of using the openapi-generator-cli to generate a java client from the octopus-energy-api.yaml file:
+
+```
+cd openapi
+
+docker run \
+    --rm \
+    -v "${PWD}:/files" \
+    openapitools/openapi-generator-cli \
+    generate \
+    -i /files/spec.yaml \
+    -g java \
+    -o /files/client/
+```
+
+See https://github.com/OpenAPITools/openapi-generator/ for full documentation on the openapi-generator.

--- a/openapi/README.md
+++ b/openapi/README.md
@@ -1,11 +1,11 @@
-# How to use the Swagger UI Try it out feature against your own Powerwall
+# Swagger UI Try it out feature
 
-For information on using the Swagger Try It Out feature, head to USING-SWAGGER-TRY-IT-OUT.md
+For information on using the Swagger Try It Out feature, head to [USING-SWAGGER-TRY-IT-OUT.md](USING-SWAGGER-TRY-IT-OUT.md)
 
 # Generating clients using OpenAPI Generator
 
-For information on generating HTTP clients from the spec.yaml, head to GENERATING-CLIENTS-USING-OPENAPI-GENERATOR.md
+For information on generating HTTP clients from the spec.yaml, head to [GENERATING-CLIENTS-USING-OPENAPI-GENERATOR.md](GENERATING-CLIENTS-USING-OPENAPI-GENERATOR.md)
 
 # Contributing
 
-If you can help out with the OpenAPI spec, please read CONTRIBUTING.md
+If you can help out with the OpenAPI spec, please read [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/openapi/README.md
+++ b/openapi/README.md
@@ -1,0 +1,11 @@
+# How to use the Swagger UI Try it out feature against your own Powerwall
+
+For information on using the Swagger Try It Out feature, head to USING-SWAGGER-TRY-IT-OUT.md
+
+# Generating clients using OpenAPI Generator
+
+For information on generating HTTP clients from the spec.yaml, head to GENERATING-CLIENTS-USING-OPENAPI-GENERATOR.md
+
+# Contributing
+
+If you can help out with the OpenAPI spec, please read CONTRIBUTING.md

--- a/openapi/USING-SWAGGER-TRY-IT-OUT.md
+++ b/openapi/USING-SWAGGER-TRY-IT-OUT.md
@@ -1,13 +1,13 @@
 ## How to use the Swagger UI Try it out feature against your own Powerwall
 
-**NOTE**: _the below does require technical knowledge of how to use nginx or the equivilent reverse proxy._
+**NOTE**: _the below does require technical knowledge of how to use nginx or the equivalent reverse proxy._
 
 One of the advantages of the Swagger UI is that you can use the "Try it out" button to test the endpoints against your own Powerwall.
 
 To use the Swagger UI to make requests to your Powerwall, you will need a reverse proxy that can route requests to your Powerwall.
-    The reverse proxy is required because the Swagger UI will make reuqests to your from a different origin than your Powerwall hostname
+    The reverse proxy is required because the Swagger UI will make requests to your from a different origin than your Powerwall hostname
     [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS).  Using a reverse proxy enables you to add additional headers,
-    required to fullfill the CORS request requirements.
+    required to fulfill the CORS request requirements.
 
 The following is an example of a reverse proxy configuration that will work with the Swagger UI.  This example uses nginx, but you
     can use any reverse proxy that supports CORS.

--- a/openapi/docker-compose.yaml
+++ b/openapi/docker-compose.yaml
@@ -1,0 +1,7 @@
+services:
+  nginx:
+    image: nginx:latest
+    ports:
+      - "80:80"
+    volumes:
+      - ./:/usr/share/nginx/html

--- a/openapi/paths/login/basic.yaml
+++ b/openapi/paths/login/basic.yaml
@@ -37,6 +37,24 @@ post:
         application/json:
           schema:
             type: object
+            properties:
+              email:
+                type: string
+              firstname:
+                type: string
+              lastname:
+                type: string
+              roles:
+                type: array
+                items: 
+                  type: string
+              token:
+                type: string
+              provider:
+                type: string
+              loginTime:
+                type: string
+                format: date-time
           examples:
             response:
               externalValue: "https://raw.githubusercontent.com/vloschiavo/powerwall2/master/samples/api-login-basic.json"

--- a/openapi/paths/meters/aggregates.yaml
+++ b/openapi/paths/meters/aggregates.yaml
@@ -41,6 +41,15 @@ get:
         application/json:
           schema:
             type: object
+            properties:
+              site:
+                $ref: '../../spec.yaml#/components/schemas/MetersAggregatesMeter'
+              battery:
+                $ref: '../../spec.yaml#/components/schemas/MetersAggregatesMeter'
+              load:
+                $ref: '../../spec.yaml#/components/schemas/MetersAggregatesMeter'
+              solar:
+                $ref: '../../spec.yaml#/components/schemas/MetersAggregatesMeter'
           examples:
             response:
               summary: Example 1

--- a/openapi/paths/system/update/status.yaml
+++ b/openapi/paths/system/update/status.yaml
@@ -34,9 +34,9 @@ get:
 
     Southern California Edison has TOU plan with the following details:
 
-    - 8am-2pm,  8pm-10pm  - offpeak
+    - 8am-2pm,  8pm-10pm  - off-peak
     - 2pm-8pm  - peak
-    - 10pm-8am  - super offpeak
+    - 10pm-8am  - super off-peak
   security:
     - bearerAuth: []
   responses:

--- a/openapi/paths/system_status/soe.yaml
+++ b/openapi/paths/system_status/soe.yaml
@@ -11,6 +11,12 @@ get:
         application/json:
           schema:
             type: object
+            properties:
+              percentage:
+                type: number
+                format: double
+                description: The percentage of charge in the Powerwall(s).
+                example: 100
           examples:
             response:
               externalValue: 'https://raw.githubusercontent.com/vloschiavo/powerwall2/master/samples/21.44-foogod/running/system_status.soe.json'

--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -11,7 +11,7 @@ info:
 
     This documentation is a work in progress. If you find any endpoints that are not documented, or are out of date, please contribute a
       pull request on the [GitHub repository](https://github.com/vloschiavo/powerwall2).  Not all of the endpoints in the README.md have
-      been converted over to OpenAPI spec.  Endponts removed from [README.md.workingcopy](README.md.workingcopy) have been converted over
+      been converted over to OpenAPI spec.  Endpoints removed from [README.md.workingcopy](README.md.workingcopy) have been converted over
       and those remaining in README.md.workingcopy have not been converted over yet.  Please see [CONTRIBUTING.md](CONTRIBUTING.md) for
       more information on how to contribute.
 
@@ -77,6 +77,62 @@ components:
     ServiceUnavailable:
       description: |
         Service Unavailable
+  schemas:
+    MetersAggregatesMeter:
+      type: object
+      properties:
+        last_communication_time:
+          type: string
+          format: date-time
+        instant_power:
+          type: number
+          format: double
+        instant_reactive_power:
+          type: number
+          format: double
+        instant_apparent_power:
+          type: number
+          format: double
+        frequency:
+          type: number
+          format: double
+        energy_exported:
+          type: number
+          format: double
+        energy_imported:
+          type: number
+          format: double
+        instant_average_voltage:
+          type: number
+          format: double
+        instant_average_current:
+          type: number
+          format: double
+        i_a_current:
+          type: number
+          format: double
+        i_b_current:
+          type: number
+          format: double
+        i_c_current:
+          type: number
+          format: double
+        last_phase_voltage_communication_time:
+          type: string
+          format: date-time
+        last_phase_power_communication_time:
+          type: string
+          format: date-time
+        last_phase_energy_communication_time:
+          type: string
+          format: date-time
+        timeout:
+          type: number
+        num_meters_aggregated:
+          type: number
+        instant_total_current:
+          type: number
+          format: double
 paths:
   /{e}:
     $ref: "./paths/e.yaml"


### PR DESCRIPTION
When using the new OpenAPI spec file to generate a client, if the response is spec'd, the client is generated with a typed class vs. plain object (was using Java).  So, have documented the responses for the three endpoints I use at home.

There's a few other minor spelling tidyups and some notes on how to run the Swagger UI locally using nginx.